### PR TITLE
add application type in output for AC, HP and DH

### DIFF
--- a/src/geophires_x/Outputs.py
+++ b/src/geophires_x/Outputs.py
@@ -1516,7 +1516,8 @@ class Outputs:
                 f.write('                           ***SUMMARY OF RESULTS***\n')
                 f.write(NL)
                 f.write('      End-Use Option: ' + str(model.surfaceplant.enduse_option.value.value) + NL)
-
+                if model.surfaceplant.plant_type.value in [PlantType.ABSORPTION_CHILLER, PlantType.HEAT_PUMP, PlantType.DISTRICT_HEATING]:
+                    f.write('      Surface Application: ' + str(model.surfaceplant.plant_type.value.value) + NL)
                 if model.surfaceplant.enduse_option.value in [EndUseOptions.ELECTRICITY, EndUseOptions.COGENERATION_TOPPING_EXTRA_HEAT, EndUseOptions.COGENERATION_TOPPING_EXTRA_ELECTRICITY, EndUseOptions.COGENERATION_BOTTOMING_EXTRA_ELECTRICITY, EndUseOptions.COGENERATION_BOTTOMING_EXTRA_HEAT, EndUseOptions.COGENERATION_PARALLEL_EXTRA_HEAT, EndUseOptions.COGENERATION_PARALLEL_EXTRA_ELECTRICITY]: # there is an electricity component
                     f.write(f'      Average Net Electricity Production:               {np.average(model.surfaceplant.NetElectricityProduced.value):10.2f} ' + model.surfaceplant.NetElectricityProduced.CurrentUnits.value + NL)
                 if model.surfaceplant.enduse_option.value != EndUseOptions.ELECTRICITY:    # there is a direct-use component

--- a/tests/examples/example10_HP.out
+++ b/tests/examples/example10_HP.out
@@ -13,6 +13,7 @@ Simulation Metadata
                            ***SUMMARY OF RESULTS***
 
       End-Use Option: Direct-Use Heat
+	  Surface Application: Heat Pump
       Average Direct-Use Heat Production:                    16.64 MW
       Direct-Use heat breakeven price (LCOH):                 14.49 USD/MMBTU
       Number of production wells:                             2

--- a/tests/examples/example11_AC.out
+++ b/tests/examples/example11_AC.out
@@ -13,6 +13,7 @@ Simulation Metadata
                            ***SUMMARY OF RESULTS***
 
       End-Use Option: Direct-Use Heat
+	  Surface Application: Absorption Chiller
       Average Direct-Use Heat Production:                     8.49 MW
       Average Cooling Production:                             5.50 MW
       Direct-Use Cooling Breakeven Price (LCOC):              17.52 USD/MMBTU

--- a/tests/examples/example12_DH.out
+++ b/tests/examples/example12_DH.out
@@ -13,6 +13,7 @@ Simulation Metadata
                            ***SUMMARY OF RESULTS***
 
       End-Use Option: Direct-Use Heat
+	  Surface Application: District Heating
       Average Direct-Use Heat Production:                    19.15 MW
       Annual District Heating Demand:                       242.90 GWh/year
       Average Annual Geothermal Heat Production:            144.70 GWh/year


### PR DESCRIPTION
Addresses https://github.com/NREL/GEOPHIRES-X/issues/93
Also shows direct-use application for district heating and heat pump (which was not showing either)