### PR TITLE
Fix virtual environment activation command for Windows

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,7 +100,7 @@ Steps:
 
    - Windows::
 
-       venv\Scripts\Activate.ps1
+       venv\Scripts\activate
 
    - macOS/Linux::
 


### PR DESCRIPTION
Updated the virtual environment activation command for Windows in the README file. Previously, executing **`venv\Scripts\Activate.ps1`** would open a text editor instead of activating the virtual environment. 