### PR TITLE
Fix docs rendering issue

### DIFF
--- a/src/geophires_x/Economics.py
+++ b/src/geophires_x/Economics.py
@@ -800,25 +800,26 @@ class Economics:
             AllowableRange=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17],
             UnitType=Units.NONE,
             ErrMessage="assume default well drilling cost correlation (10)",
-            ToolTipText="""Select the built-in well drilling and completion cost correlation:
-1. vertical small diameter, baseline;
-2. deviated small diameter, baseline;
-3. vertical large diameter, baseline;
-4. deviated large diameter, baseline;
-5. Simple;
-6. vertical small diameter, intermediate1;
-7. vertical small diameter, intermediate2;
-8. deviated small diameter, intermediate1;
-9. deviated small diameter, intermediate2;
-10. vertical large diameter, intermediate1;
-11. vertical large diameter, intermediate2;
-12. deviated large diameter, intermediate1;
-13. deviated large diameter, intermediate2;
-14. vertical open-hole, small diameter, ideal;
-15. deviated liner, small diameter, ideal;
-16. vertical open-hole, large diameter, ideal;
-17. deviated liner, large diameter, ideal;"""
+            ToolTipText="Select the built-in well drilling and completion cost correlation: " +
+                        "1. vertical small diameter, baseline; " +
+                        "2. deviated small diameter, baseline; " +
+                        "3. vertical large diameter, baseline; " +
+                        "4. deviated large diameter, baseline; " +
+                        "5. Simple; " +
+                        "6. vertical small diameter, intermediate1; " +
+                        "7. vertical small diameter, intermediate2; " +
+                        "8. deviated small diameter, intermediate1; " +
+                        "9. deviated small diameter, intermediate2; " +
+                        "10. vertical large diameter, intermediate1; " +
+                        "11. vertical large diameter, intermediate2; " +
+                        "12. deviated large diameter, intermediate1; " +
+                        "13. deviated large diameter, intermediate2; " +
+                        "14. vertical open-hole, small diameter, ideal; " +
+                        "15. deviated liner, small diameter, ideal; " +
+                        "16. vertical open-hole, large diameter, ideal; " +
+                        "17. deviated liner, large diameter, ideal"
         )
+
         self.DoAddOnCalculations = self.ParameterDict[self.DoAddOnCalculations.Name] = boolParameter(
             "Do AddOn Calculations",
             DefaultValue=False,

--- a/src/geophires_x_schema_generator/geophires-request.json
+++ b/src/geophires_x_schema_generator/geophires-request.json
@@ -731,7 +731,7 @@
       "category": "Economics"
     },
     "Well Drilling Cost Correlation": {
-      "description": "Select the built-in horizontal well drilling and completion cost correlation. 1. vertical small diameter, baseline; 2. deviated small diameter, baseline; 3. vertical large diameter, baseline; 4. deviated large diameter, baseline; 5. Simple; 6. vertical small diameter, intermediate1; 7. vertical small diameter, intermediate2; 8. deviated small diameter, intermediate1; 9. deviated small diameter, intermediate2; 10. vertical large diameter, intermediate1; 11. vertical large diameter, intermediate2; 12. deviated large diameter, intermediate1; 13. deviated large diameter, intermediate2; 14. vertical open-hole, small diameter, ideal; 15. deviated liner, small diameter, ideal; 16. vertical open-hole, large diameter, ideal; 17. deviated liner, large diameter, ideal",
+      "description": "Select the built-in well drilling and completion cost correlation: 1. vertical small diameter, baseline; 2. deviated small diameter, baseline; 3. vertical large diameter, baseline; 4. deviated large diameter, baseline; 5. Simple; 6. vertical small diameter, intermediate1; 7. vertical small diameter, intermediate2; 8. deviated small diameter, intermediate1; 9. deviated small diameter, intermediate2; 10. vertical large diameter, intermediate1; 11. vertical large diameter, intermediate2; 12. deviated large diameter, intermediate1; 13. deviated large diameter, intermediate2; 14. vertical open-hole, small diameter, ideal; 15. deviated liner, small diameter, ideal; 16. vertical open-hole, large diameter, ideal; 17. deviated liner, large diameter, ideal",
       "type": "integer",
       "units": null,
       "category": "Economics"
@@ -986,6 +986,36 @@
       "description": "CHP Electrical Plant Cost Allocation Ratio (cost electrical plant/total CAPEX)",
       "type": "number",
       "units": "",
+      "category": "Economics"
+    },
+    "Production Tax Credit Electricity": {
+      "description": "Production tax credit for electricity in $/kWh",
+      "type": "number",
+      "units": "USD/kWh",
+      "category": "Economics"
+    },
+    "Production Tax Credit Heat": {
+      "description": "Production tax credit for heat in $/MMBTU",
+      "type": "number",
+      "units": "USD/MMBTU",
+      "category": "Economics"
+    },
+    "Production Tax Credit Cooling": {
+      "description": "Production tax credit for cooling in $/MMBTU",
+      "type": "number",
+      "units": "USD/MMBTU",
+      "category": "Economics"
+    },
+    "Production Tax Credit Duration": {
+      "description": "Production tax credit for duration in years",
+      "type": "integer",
+      "units": "yr",
+      "category": "Economics"
+    },
+    "Production Tax Credit Inflation Adjusted": {
+      "description": "Production tax credit inflation adjusted",
+      "type": "boolean",
+      "units": null,
       "category": "Economics"
     },
     "Operation & Maintenance Cost of Surface Plant": {


### PR DESCRIPTION
Newlines in updated well drilling cost correlation were causing rendering issue in docs, now fixed:

<img width="958" alt="Screenshot 2024-04-22 at 12 10 39" src="https://github.com/NREL/GEOPHIRES-X/assets/4056124/84e5e131-cb2b-4962-a041-31b2847ac4f1">
