### PR TITLE
Correct BaseTestCase import in test files

### DIFF
--- a/tests/geophires_x_client_tests/test_geophires_input_parameters.py
+++ b/tests/geophires_x_client_tests/test_geophires_input_parameters.py
@@ -2,8 +2,8 @@ import tempfile
 import uuid
 from pathlib import Path
 
-from base_test_case import BaseTestCase
 from geophires_x_client import GeophiresInputParameters
+from tests.base_test_case import BaseTestCase
 
 
 class GeophiresInputParametersTestCase(BaseTestCase):

--- a/tests/geophires_x_tests/test_cylindrical_reservoir.py
+++ b/tests/geophires_x_tests/test_cylindrical_reservoir.py
@@ -2,7 +2,7 @@ import math
 import unittest
 from pathlib import Path
 
-from base_test_case import BaseTestCase
+from tests.base_test_case import BaseTestCase
 
 # Ruff disabled because imports are order-dependent
 # ruff: noqa: I001

--- a/tests/geophires_x_tests/test_economics.py
+++ b/tests/geophires_x_tests/test_economics.py
@@ -1,5 +1,5 @@
-from base_test_case import BaseTestCase
 from geophires_x.Economics import CalculateFinancialPerformance
+from tests.base_test_case import BaseTestCase
 
 
 class EconomicsTestCase(BaseTestCase):

--- a/tests/geophires_x_tests/test_reservoir.py
+++ b/tests/geophires_x_tests/test_reservoir.py
@@ -4,10 +4,10 @@ from pathlib import Path
 
 from pint.facets.plain import PlainQuantity
 
-from base_test_case import BaseTestCase
 from geophires_x.GeoPHIRESUtils import static_pressure_MPa
 from geophires_x.Model import Model
 from geophires_x.Reservoir import Reservoir
+from tests.base_test_case import BaseTestCase
 
 
 class ReservoirTestCase(BaseTestCase):

--- a/tests/test_base_test_case.py
+++ b/tests/test_base_test_case.py
@@ -1,6 +1,6 @@
 import unittest
 
-from base_test_case import BaseTestCase
+from tests.base_test_case import BaseTestCase
 
 
 class TestBaseTestCase(BaseTestCase):

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -3,7 +3,6 @@ import sys
 import unittest
 from pathlib import Path
 
-from base_test_case import BaseTestCase
 from geophires_x.Model import Model
 from geophires_x.Parameter import OutputParameter
 from geophires_x.Parameter import Parameter
@@ -14,6 +13,7 @@ from geophires_x.Units import EnergyCostUnit
 from geophires_x.Units import LengthUnit
 from geophires_x.Units import PressureUnit
 from geophires_x.Units import Units
+from tests.base_test_case import BaseTestCase
 
 
 class ParameterTestCase(BaseTestCase):


### PR DESCRIPTION
This PR fixes issue #228 
I corrected the import statement for the BaseTestCase class in the 6 test files, ensuring it is imported correctly. Previously, the import statement was not functioning as intended, leading to import errors during local testing.