### PR TITLE
Initial steps for Code Coverage Integration

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -167,7 +167,7 @@ jobs:
         coverage run -m unittest
 
     - name: Upload Coverage to Codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v4
 
     - name: upload artifact
       uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -142,6 +142,7 @@ jobs:
       run: |
         python -mpip install --upgrade pip
         python -mpip install --progress-bar=off -r ci/requirements.txt
+        python -mpip install coverage
         virtualenv --version
         pip --version
         tox --version
@@ -160,6 +161,13 @@ jobs:
         chmod -c -R +rX "_site/" | while read line; do
           echo "::warning title=Invalid file permissions automatically fixed::$line"
         done
+
+    - name: Generate Report
+      run: |
+        coverage run -m unittest
+
+    - name: Upload Coverage to Codecov
+      uses: codecov/codecov-action@v2
 
     - name: upload artifact
       uses: actions/upload-pages-artifact@v3

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -4,3 +4,4 @@ setuptools>=18.0.1
 six>=1.14.0
 tox
 twine
+coverage


### PR DESCRIPTION
This draft PR addresses initial steps for integrating code coverage, related to issue #22. I have added coverage to requirements.txt and updated github actions.yml to begin setting up code coverage. The changes have passed build checks, but they do not yet generate or display a coverage badge. 
The next steps include completing the coverage report generation and adding the coverage badge to the README. 