### PR TITLE
changes invertlaplace method to Stehfest Algorithm to make Gringarten model more stable

### DIFF
--- a/src/geophires_x/MPFReservoir.py
+++ b/src/geophires_x/MPFReservoir.py
@@ -88,7 +88,7 @@ class MPFReservoir(Reservoir):
         Twnd = []
         try:
             for t in range(1, len(model.reserv.timevector.value)):
-                Twnd = Twnd + [float(invertlaplace(fp, td[t], method='talbot'))]
+                Twnd = Twnd + [float(invertlaplace(fp, td[t], method='stehfest'))]
         except:
             print(
                 "Error: GEOPHIRES could not execute numerical inverse laplace calculation for reservoir model 1. Simulation will abort.")

--- a/tests/examples/Fervo_Norbeck_Latimer_2023.out
+++ b/tests/examples/Fervo_Norbeck_Latimer_2023.out
@@ -4,10 +4,10 @@
 
 Simulation Metadata
 ----------------------
- GEOPHIRES Version: 3.4.42
- Simulation Date: 2024-07-17
- Simulation Time:  11:19
- Calculation Time:      0.353 sec
+ GEOPHIRES Version: 3.5.0
+ Simulation Date: 2024-07-24
+ Simulation Time:  18:06
+ Calculation Time:      1.152 sec
 
                            ***SUMMARY OF RESULTS***
 
@@ -144,7 +144,7 @@ Simulation Metadata
    6           1.0129                184.12               0.6919            2.1612                8.8239
    7           1.0129                184.13               0.6920            2.1612                8.8237
    8           1.0108                183.75               0.6925            2.1430                8.7720
-   9           1.0019                182.13               0.6948            2.0640                8.5463
+   9           1.0019                182.13               0.6948            2.0640                8.5464
   10           0.9771                177.63               0.7009            1.8532                7.9258
 
 


### PR DESCRIPTION
Addresses issue https://github.com/NREL/GEOPHIRES-X/issues/264
Increasing fracture area made Inverse Laplace method used in Gringarten reservoir model (MPF model) unstable (flow per fracture divided by fracture area became too small). Switching from the Talbot to the Stehfest Algorithm fixes this issue and allows running with fracture area of 320 m by 320 m. 