### PR TITLE
No longer setting CurrentUnits = PreferredUnits (issue 95)

### DIFF
--- a/src/geophires_x/Economics.py
+++ b/src/geophires_x/Economics.py
@@ -1822,9 +1822,7 @@ class Economics:
                 key = ParameterToModify.Name.strip()
                 if key in model.InputParameters:
                     ParameterReadIn = model.InputParameters[key]
-                    # Before we change the parameter, let's assume that the unit preferences will match
-                    # - if they don't, the later code will fix this.
-                    ParameterToModify.CurrentUnits = ParameterToModify.PreferredUnits
+
                     # this should handle all the non-special cases
                     ReadParameter(ParameterReadIn, ParameterToModify, model)
 

--- a/src/geophires_x/EconomicsS_DAC_GT.py
+++ b/src/geophires_x/EconomicsS_DAC_GT.py
@@ -366,9 +366,7 @@ class EconomicsS_DAC_GT(Economics.Economics):
                 key = ParameterToModify.Name.strip()
                 if key in model.InputParameters:
                     ParameterReadIn = model.InputParameters[key]
-                    # Before we change the paremater, let's assume that the unit preferences will match -
-                    # if they don't, the later code will fix this.
-                    ParameterToModify.CurrentUnits = ParameterToModify.PreferredUnits
+
                     # this should handle all the non-special cases
                     ReadParameter(ParameterReadIn, ParameterToModify, model)
 

--- a/src/geophires_x/Outputs.py
+++ b/src/geophires_x/Outputs.py
@@ -721,9 +721,6 @@ class Outputs:
                             model.logger.info(f'Adjusted {key} path to {ParameterReadIn.sValue} because original value '
                                               f'({original_val}) was not an absolute path.')
 
-                    # Before we change the parameter, let's assume that the unit preferences will match
-                    # - if they don't, the later code will fix this.
-                    ParameterToModify.CurrentUnits = ParameterToModify.PreferredUnits
                     # this should handle all the non-special cases
                     ReadParameter(ParameterReadIn, ParameterToModify, model)
 
@@ -1674,7 +1671,7 @@ class Outputs:
                 f.write(f'      Number of Injection Wells:                     {model.wellbores.ninj.value:10.0f}' + NL)
                 f.write(f'      Well depth (or total length, if not vertical):   {model.reserv.depth.value:10.1f} ' + model.reserv.depth.CurrentUnits.value + NL)
                 f.write(f'      Water loss rate:                                 {model.reserv.waterloss.value*100:10.1f} ' + model.reserv.waterloss.CurrentUnits.value + NL)
-                f.write(f'      Pump efficiency:                                 {model.surfaceplant.pump_efficiency.value * 100:10.1f} ' + model.surfaceplant.pump_efficiency.CurrentUnits.value + NL)
+                f.write(f'      Pump efficiency:                                 {model.surfaceplant.pump_efficiency.value:10.1f} ' + model.surfaceplant.pump_efficiency.CurrentUnits.value + NL)
                 f.write(f'      Injection temperature:                           {model.wellbores.Tinj.value:10.1f} ' + model.wellbores.Tinj.CurrentUnits.value + NL)
                 if model.wellbores.rameyoptionprod.value:
                     f.write('      Production Wellbore heat transmission calculated with Ramey\'s model\n')

--- a/src/geophires_x/Parameter.py
+++ b/src/geophires_x/Parameter.py
@@ -289,9 +289,12 @@ def ReadParameter(ParameterReadIn: ParameterEntry, ParamToModify, model):
         new_str = ConvertUnits(ParamToModify, ParameterReadIn.sValue, model)
         if len(new_str) > 0:
             ParameterReadIn.sValue = new_str
-    else:
-        # The value came in without any units, so it must be using the default PreferredUnits
-        ParamToModify.CurrentUnits = ParamToModify.PreferredUnits
+    #else:
+        # The value came in without any units
+        # TODO: determine the proper action in this case
+        # (previously, it was assumed that the value must be
+        # using the default PreferredUnits, which was not always
+        # valid and led to incorrect units in the output)
 
     def default_parameter_value_message(new_val: Any, param_to_modify_name: str, default_value: Any) -> str:
         return (

--- a/src/geophires_x/Reservoir.py
+++ b/src/geophires_x/Reservoir.py
@@ -549,12 +549,9 @@ class Reservoir:
                 if key in model.InputParameters:
                     ParameterReadIn = model.InputParameters[key]
 
-                    # Before we change the parameter, let's assume that the unit preferences will match -
-                    # if they don't, the later code will fix this.
                     # TODO: refactor GEOPHIRES such that parameters are read in immutably and only accessed with
                     #  explicit units, with conversion only occurring in the getter as necessary
 
-                    ParameterToModify.CurrentUnits = ParameterToModify.PreferredUnits
                     ReadParameter(ParameterReadIn, ParameterToModify, model)  # this handles all non-special cases
 
                     # handle special cases

--- a/src/geophires_x/SBTReservoir.py
+++ b/src/geophires_x/SBTReservoir.py
@@ -326,12 +326,9 @@ class SBTReservoir(CylindricalReservoir):
                 if key in model.InputParameters:
                     ParameterReadIn = model.InputParameters[key]
 
-                    # Before we change the parameter, let's assume that the unit preferences will match -
-                    # if they don't, the later code will fix this.
                     # TODO: refactor GEOPHIRES such that parameters are read in immutably and only accessed with
                     #  explicit units, with conversion only occurring in the getter as necessary
 
-                    ParameterToModify.CurrentUnits = ParameterToModify.PreferredUnits
                     ReadParameter(ParameterReadIn, ParameterToModify, model)  # this handles all non-special cases
 
                     # handle special cases

--- a/src/geophires_x/SUTRAEconomics.py
+++ b/src/geophires_x/SUTRAEconomics.py
@@ -316,9 +316,7 @@ class SUTRAEconomics(Economics.Economics):
                 key = ParameterToModify.Name.strip()
                 if key in model.InputParameters:
                     ParameterReadIn = model.InputParameters[key]
-                    # Before we change the parameter, let's assume that the unit preferences will match
-                    # - if they don't, the later code will fix this.
-                    ParameterToModify.CurrentUnits = ParameterToModify.PreferredUnits
+
                     # this should handle all the non-special cases
                     ReadParameter(ParameterReadIn, ParameterToModify, model)
 

--- a/src/geophires_x/SUTRAWellBores.py
+++ b/src/geophires_x/SUTRAWellBores.py
@@ -215,9 +215,6 @@ class SUTRAWellBores(WellBores):
                 key = ParameterToModify.Name.strip()
                 if key in model.InputParameters:
                     ParameterReadIn = model.InputParameters[key]
-                    # Before we change the parameter, let's assume that the unit preferences will match
-                    # - if they don't, the later code will fix this.
-                    ParameterToModify.CurrentUnits = ParameterToModify.PreferredUnits
                     ReadParameter(ParameterReadIn, ParameterToModify, model)  # this should handle all non-special cases
 
                     # handle special cases

--- a/src/geophires_x/SurfacePlant.py
+++ b/src/geophires_x/SurfacePlant.py
@@ -258,7 +258,7 @@ class SurfacePlant:
             Min=0.1,
             Max=1.0,
             UnitType=Units.PERCENT,
-            PreferredUnits=PercentUnit.TENTH,
+            PreferredUnits=PercentUnit.PERCENT,
             CurrentUnits=PercentUnit.TENTH,
             Required=True,
             ErrMessage="assume default circulation pump efficiency (0.75)",
@@ -551,9 +551,7 @@ class SurfacePlant:
                 key = ParameterToModify.Name.strip()
                 if key in model.InputParameters:
                     ParameterReadIn = model.InputParameters[key]
-                    # Before we change the parameter, let's assume that the unit preferences will match -
-                    # if they don't, the later code will fix this.
-                    ParameterToModify.CurrentUnits = ParameterToModify.PreferredUnits
+
                     # this should handle all the non-special cases
                     ReadParameter(ParameterReadIn, ParameterToModify, model)
 
@@ -563,7 +561,6 @@ class SurfacePlant:
                         ParameterToModify.value = end_use_option
                         if end_use_option == EndUseOptions.HEAT:
                             self.plant_type.value = PlantType.INDUSTRIAL
-
                     elif ParameterToModify.Name == 'Power Plant Type':
                         ParameterToModify.value = PlantType.from_input_string(ParameterReadIn.sValue)
                         if self.enduse_option.value == EndUseOptions.ELECTRICITY:

--- a/src/geophires_x/WellBores.py
+++ b/src/geophires_x/WellBores.py
@@ -1254,9 +1254,6 @@ class WellBores:
                 key = ParameterToModify.Name.strip()
                 if key in model.InputParameters:
                     ParameterReadIn = model.InputParameters[key]
-                    # Before we change the parameter, let's assume that the unit preferences will match
-                    # - if they don't, the later code will fix this.
-                    ParameterToModify.CurrentUnits = ParameterToModify.PreferredUnits
                     ReadParameter(ParameterReadIn, ParameterToModify, model)  # this should handle all non-special cases
 
                     # handle special cases

--- a/src/hip_ra/HIP_RA.py
+++ b/src/hip_ra/HIP_RA.py
@@ -623,9 +623,6 @@ class HIP_RA:
                 key = ParameterToModify.Name.strip()
                 if key in self.InputParameters:
                     ParameterReadIn = self.InputParameters[key]
-                    # Before we change the parameter, let's assume that the unit preferences will match -
-                    # if they don't, the later code will fix this.
-                    ParameterToModify.CurrentUnits = ParameterToModify.PreferredUnits
                     ReadParameter(
                         ParameterReadIn, ParameterToModify, self
                     )  # this should handle all the non-special cases

--- a/src/hip_ra_x/hip_ra_x.py
+++ b/src/hip_ra_x/hip_ra_x.py
@@ -612,9 +612,7 @@ class HIP_RA_X:
                 key = ParameterToModify.Name.strip()
                 if key in self.InputParameters:
                     ParameterReadIn = self.InputParameters[key]
-                    # Before we change the parameter, let's assume that the unit preferences will match -
-                    # if they don't, the later code will fix this.
-                    ParameterToModify.CurrentUnits = ParameterToModify.PreferredUnits
+
                     # this should handle all the non-special cases
                     ReadParameter(ParameterReadIn, ParameterToModify, self)
         else:

--- a/tests/examples/Fervo_Norbeck_Latimer_2023.txt
+++ b/tests/examples/Fervo_Norbeck_Latimer_2023.txt
@@ -14,7 +14,7 @@
 Reservoir Model, 1
 Reservoir Volume Option, 1,
 Reservoir Density, 2800, per the paper phyllite + quartzite + diorite + granodiorite,
-Reservoir Depth, 7700 feet, per the paper
+Reservoir Depth, 7700 ft, per the paper
 Reservoir Heat Capacity, 1000
 Reservoir Thermal Conductivity, 2.7
 Number of Fractures, 100, per the paper
@@ -31,13 +31,13 @@ Well Geometry Configuration, 4
 Has Nonvertical Section, True
 Multilaterals Cased, True
 Number of Multilateral Sections, 2, Two parallel horizontal sections
-Nonvertical Length per Multilateral Section, 3250 feet, per the paper
+Nonvertical Length per Multilateral Section, 3250 ft, per the paper
 Well Drilling Cost Correlation, 10,	per the drill cost paper - works out to $400/ft
 Horizontal Well Drilling Cost Correlation, 10,	per the drill cost paper - works out to $400/ft
 Production Flow Rate per Well, 41.02, =650 gpm per the paper - per the paper the maximum flow rate was 63 L/s but the range was 550-750 gpm
 Production Well Diameter, 7, per the paper
 Injection Well Diameter, 7, per the paper
-Well Separation, 365 feet, per the paper
+Well Separation, 365 ft, per the paper
 Injection Temperature, 38 degC, per the paper 75 to 125 degF
 Injection Wellbore Temperature Gain, 3
 Reservoir Impedance, 0.33, per paper, matching pumping power report 500-1000 kW

--- a/tests/examples/Fervo_Project_Cape-2.txt
+++ b/tests/examples/Fervo_Project_Cape-2.txt
@@ -7,7 +7,7 @@
 Reservoir Model, 1
 Reservoir Volume Option, 1
 Reservoir Density, 2800
-Reservoir Depth, 8500 feet, -- https://pangea.stanford.edu/ERE/db/GeoConf/papers/SGW/2024/Fercho.pdf
+Reservoir Depth, 8500 ft, -- https://pangea.stanford.edu/ERE/db/GeoConf/papers/SGW/2024/Fercho.pdf
 Reservoir Heat Capacity, 790
 Reservoir Thermal Conductivity, 3.05
 Reservoir Porosity, 0.0118
@@ -27,7 +27,7 @@ Number of Production Wells, 1
 Production Flow Rate per Well, 93
 Production Well Diameter, 7
 Injection Well Diameter, 7
-Well Separation, 365 feet
+Well Separation, 365 ft
 Injection Temperature, 60 degC
 Injection Wellbore Temperature Gain, 3
 Plant Outlet Pressure, 1000 psi
@@ -69,4 +69,4 @@ Well Geometry Configuration, 4
 Has Nonvertical Section, True
 Multilaterals Cased, True
 Number of Multilateral Sections, 3
-Nonvertical Length per Multilateral Section, 4700 feet
+Nonvertical Length per Multilateral Section, 4700 ft

--- a/tests/examples/Fervo_Project_Cape-3.txt
+++ b/tests/examples/Fervo_Project_Cape-3.txt
@@ -8,7 +8,7 @@
 Reservoir Model, 1
 Reservoir Volume Option, 1
 Reservoir Density, 2800
-Reservoir Depth, 8500 feet, -- https://pangea.stanford.edu/ERE/db/GeoConf/papers/SGW/2024/Fercho.pdf
+Reservoir Depth, 8500 ft, -- https://pangea.stanford.edu/ERE/db/GeoConf/papers/SGW/2024/Fercho.pdf
 Reservoir Heat Capacity, 790
 Reservoir Thermal Conductivity, 3.05
 Reservoir Porosity, 0.0118
@@ -28,7 +28,7 @@ Number of Production Wells, 39
 Production Flow Rate per Well, 120, -- peak flow reported in paper
 Production Well Diameter, 7
 Injection Well Diameter, 7
-Well Separation, 365 feet
+Well Separation, 365 ft
 Injection Temperature, 60 degC
 Injection Wellbore Temperature Gain, 3
 Plant Outlet Pressure, 1000 psi
@@ -69,4 +69,4 @@ Well Geometry Configuration, 4
 Has Nonvertical Section, True
 Multilaterals Cased, True
 Number of Multilateral Sections, 3
-Nonvertical Length per Multilateral Section, 4700 feet
+Nonvertical Length per Multilateral Section, 4700 ft

--- a/tests/examples/Fervo_Project_Cape.txt
+++ b/tests/examples/Fervo_Project_Cape.txt
@@ -4,7 +4,7 @@
 Reservoir Model, 1
 Reservoir Volume Option, 1
 Reservoir Density, 2800
-Reservoir Depth, 8500 feet, -- https://pangea.stanford.edu/ERE/db/GeoConf/papers/SGW/2024/Fercho.pdf
+Reservoir Depth, 8500 ft, -- https://pangea.stanford.edu/ERE/db/GeoConf/papers/SGW/2024/Fercho.pdf
 Reservoir Heat Capacity, 1000
 Reservoir Thermal Conductivity, 2.7
 Number of Fractures, 100
@@ -21,11 +21,11 @@ Well Geometry Configuration, 4
 Has Nonvertical Section, True
 Multilaterals Cased, True
 Number of Multilateral Sections, 2
-Nonvertical Length per Multilateral Section, 5000 feet
+Nonvertical Length per Multilateral Section, 5000 ft
 Production Flow Rate per Well, 98
 Production Well Diameter, 8
 Injection Well Diameter, 8
-Well Separation, 365 feet
+Well Separation, 365 ft
 Injection Temperature, 60 degC
 Injection Wellbore Temperature Gain, 3
 Reservoir Impedance, 0.01


### PR DESCRIPTION
This should fix #95.  Note that examples with input units specified as "feet" were changed to "ft" for compatibility with [Units.py](https://github.com/NREL/GEOPHIRES-X/blob/main/src/geophires_x/Units.py#L113).